### PR TITLE
Made sure the weapon system easily allows addition of other guns. Readded the pistol to the system to test it. Added bullet holes.

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -9,14 +9,16 @@ InvalidTagCharacters="\"\',"
 NumBitsForContainerSize=6
 NetIndexFirstBitSegment=16
 +GameplayTagList=(Tag="GameplayCue.TakeDamage",DevComment="")
-+GameplayTagList=(Tag="Pickup.Ammo.Bullets.Small",DevComment="")
++GameplayTagList=(Tag="Pickup.Ammo.Pistol.Small",DevComment="")
++GameplayTagList=(Tag="Pickup.Ammo.Shotgun.Small",DevComment="")
 +GameplayTagList=(Tag="Pickup.Armor.Large",DevComment="")
 +GameplayTagList=(Tag="Pickup.Armor.Small",DevComment="")
 +GameplayTagList=(Tag="Pickup.Health.Large",DevComment="")
 +GameplayTagList=(Tag="Pickup.Health.Small",DevComment="")
 +GameplayTagList=(Tag="Player.Armor.Full",DevComment="")
-+GameplayTagList=(Tag="Player.FireWeapon",DevComment="")
 +GameplayTagList=(Tag="Player.Health.Full",DevComment="")
-+GameplayTagList=(Tag="Player.Pistol.Cooldown",DevComment="")
-+GameplayTagList=(Tag="Player.Shotgun.Cooldown",DevComment="")
++GameplayTagList=(Tag="Player.Weapon.Pistol.Cooldown",DevComment="")
++GameplayTagList=(Tag="Player.Weapon.Pistol.Fire",DevComment="")
++GameplayTagList=(Tag="Player.Weapon.Shotgun.Cooldown",DevComment="")
++GameplayTagList=(Tag="Player.Weapon.Shotgun.Fire",DevComment="")
 

--- a/Content/BoomerShooter/Blueprints/Abilities/GA_BulletWeaponAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/GA_BulletWeaponAbility.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f2ca0c1c4107f4574a40e88b2fd65bb173a1fff0b95d242c6777c422007dce18
-size 130122

--- a/Content/BoomerShooter/Blueprints/Abilities/GA_ShotgunAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/GA_ShotgunAbility.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b1563fdc848b622d99cd28ad39465bdb759f8943acca692f01a40a2b2f992da0
-size 183951

--- a/Content/BoomerShooter/Blueprints/Abilities/GE_BulletSpend.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/GE_BulletSpend.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d7e837c97a62e3a07a8a5f5a073eea6a86efb43eaca5e0d250f2ff4a564f7b5
-size 13079

--- a/Content/BoomerShooter/Blueprints/Abilities/GE_ShotgunCooldown.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/GE_ShotgunCooldown.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aec21160949e3f3c551071a5a6bcb1137e50e37ff9813408709a370875829fdb
-size 8012

--- a/Content/BoomerShooter/Blueprints/Abilities/GE_ShotgunDamage.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/GE_ShotgunDamage.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c30e5182e7c94338c9ae1d2fe1cccd5dee4f2ff41d4d7362dcf2bbe76ceccad1
-size 13701

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoBulletSmall.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoBulletSmall.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e53e382087ec7b6f4111b715dbcfbcc69d3f8cc70346c0b723610de122e819c8
-size 23871

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoPistolSmall.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoPistolSmall.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc4b797c999b3283e5d91638becf4f58741ca38e1c3effeac389d4b6c23e3a5b
+size 23795

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoShotgunSmall.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GA_AmmoShotgunSmall.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdfeaa2b7fca85796dbaade7677d4d841d05853a06a3e11900a7807980e943dd
+size 23606

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoBulletSmallEffect.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoBulletSmallEffect.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5c774459afed5ecb793f418bc023f00d06955feff815563e10b5bd15044cd3a5
-size 13257

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoPistolSmallEffect.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoPistolSmallEffect.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38162277493e2d2f455a92897a29f1cedb3c6826b4847ff79a222faafac93ecc
-size 12835
+oid sha256:29509a2fad1dad53b69bb1d7cffd2c06e9d4de38d007a70f4b04adc23c9cacb6
+size 13167

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoPistolSmallEffect.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoPistolSmallEffect.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38162277493e2d2f455a92897a29f1cedb3c6826b4847ff79a222faafac93ecc
+size 12835

--- a/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoShotgunSmallEffect.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/PickupAbilities/GE_AmmoShotgunSmallEffect.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7ff9e85451a4f30006ed8b75dee0c5e6d7d41b39874acd1503b6519c701795d
+size 13282

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/GA_BulletWeaponAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/GA_BulletWeaponAbility.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:837d56acfbefdd548968e8fd367177924f72b404cdf35cfe88245b3620cf62e8
+size 130941

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f3583b682343ad46387347fe5e43f0d1254a3387fa2e4c143b49b9dc8d0d5cf
+size 157974

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:59a3d78b0e1011b8ca1b9f53d5e7bc648a52fd3fd498e4fa5bf80fad877aaa62
-size 158081
+oid sha256:98a99838382a429840e9e550f4b71482ea4f5cd12ab154b15fe32ff6e6962e4e
+size 156739

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98a99838382a429840e9e550f4b71482ea4f5cd12ab154b15fe32ff6e6962e4e
-size 156739
+oid sha256:a97b17809c5b5bab6f3cdd6e8292e8550b95a53cfb3a6182e6c883bf2144618d
+size 173911

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f3583b682343ad46387347fe5e43f0d1254a3387fa2e4c143b49b9dc8d0d5cf
-size 157974
+oid sha256:59a3d78b0e1011b8ca1b9f53d5e7bc648a52fd3fd498e4fa5bf80fad877aaa62
+size 158081

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GA_PistolAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a97b17809c5b5bab6f3cdd6e8292e8550b95a53cfb3a6182e6c883bf2144618d
-size 173911
+oid sha256:d2a5458cfae95991524e7a797de9774619d0274280acacb849ca3c8bd7913158
+size 215661

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolBulletsSpend.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolBulletsSpend.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ee351995471065d571f2e5fb0de55464cdecf5ae4883cf244150ec4e462da1a
+size 12793

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolCooldown.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolCooldown.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdf9b4eec99dc07b80950d7e8b8426b2b777871f728c6110941e24d12ae15750
+size 7619

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolDamage.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Pistol/GE_PistolDamage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e05532fa8133fc3495593666feb4ec64feb01b752d5a7b445be13ef279b200ba
+size 13302

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e2bdcc2eb9702bd3de28d6580c8fdcf9de6ddb274089a51cdbd1bf962493234
+size 183841

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b0d6f406d0a69f6e54ea097cb85614a43be729428a07c24b92d56b6550134d5f
-size 200049
+oid sha256:147e5572bf33a1d4fe54240b75dbf491a863a2b03ae1ffe90c880f2d1af098e6
+size 253388

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GA_ShotgunAbility.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2e2bdcc2eb9702bd3de28d6580c8fdcf9de6ddb274089a51cdbd1bf962493234
-size 183841
+oid sha256:b0d6f406d0a69f6e54ea097cb85614a43be729428a07c24b92d56b6550134d5f
+size 200049

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunBulletSpend.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunBulletSpend.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0af4689f67c79930cecc4ba1aa7108e8a8c2e2c687fdc1b2e645f3b10856c923
+size 13562

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunCooldown.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunCooldown.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e50f4f5c1545b853486eeebfcbe443ee4b80bbb1a3fa50deb99351cf7545a800
+size 8067

--- a/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunDamage.uasset
+++ b/Content/BoomerShooter/Blueprints/Abilities/Weapons/Shotgun/GE_ShotgunDamage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a1baaa863b8040104fe07198b02de77d38a334e3a81086616dee8e788c73d27
+size 13749

--- a/Content/BoomerShooter/Blueprints/Enums/ENUM_AmmoList.uasset
+++ b/Content/BoomerShooter/Blueprints/Enums/ENUM_AmmoList.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0917d9d0d339da31bfca83c0010a94b0773a3aa21829624c08e5e26724789330
-size 2427
+oid sha256:e215994d05dc4f0edd8a0c808ce50ae504f9857503e54dec2b8cb6249d8ec7a9
+size 2817

--- a/Content/BoomerShooter/Blueprints/Enums/ENUM_WeaponList.uasset
+++ b/Content/BoomerShooter/Blueprints/Enums/ENUM_WeaponList.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19afefa6984a8685cd081c43ff88cf3042673c63f74f0f0c1fba23d4a7d80015
-size 2451
+oid sha256:914e8f667c5cb0a3b2404a01f29696f635cefce9af9f492b61a458c8f13a078b
+size 2821

--- a/Content/BoomerShooter/Blueprints/Pickups/BP_WeaponPickup.uasset
+++ b/Content/BoomerShooter/Blueprints/Pickups/BP_WeaponPickup.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3006cea53ee5fff0d199374be496cb493bf2ddaa96178c3a751bdc6a3770a5a3
-size 116561
+oid sha256:a8d9fb60978177d2574a7a88f758e782ca95308b95266cce7370205a095a83ea
+size 144196

--- a/Content/BoomerShooter/Blueprints/Pickups/BP_WeaponPickup.uasset
+++ b/Content/BoomerShooter/Blueprints/Pickups/BP_WeaponPickup.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8d9fb60978177d2574a7a88f758e782ca95308b95266cce7370205a095a83ea
-size 144196
+oid sha256:3e2d78f09a82b82a7e791f5eb7e64337294517f9340384deed3c2e6ea23d2eef
+size 141808

--- a/Content/BoomerShooter/Blueprints/Player/BP_Player.uasset
+++ b/Content/BoomerShooter/Blueprints/Player/BP_Player.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f224da4d44de1ea5ca01ad0a6c2db66c04904a16b929ea59348d72538373a5a
-size 513528
+oid sha256:2eea0e0981e9aae3e0f1ff04ef1edf6c468f12bc678e8ad1cec2125702c87107
+size 610983

--- a/Content/BoomerShooter/Blueprints/Player/BP_Player.uasset
+++ b/Content/BoomerShooter/Blueprints/Player/BP_Player.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2eea0e0981e9aae3e0f1ff04ef1edf6c468f12bc678e8ad1cec2125702c87107
-size 610983
+oid sha256:8ac2c4b473aa216270fc9c424bf38dea6253591a8981ee2b78b306e534346528
+size 609694

--- a/Content/BoomerShooter/Blueprints/Structs/ST_WeaponData.uasset
+++ b/Content/BoomerShooter/Blueprints/Structs/ST_WeaponData.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d1bcab011af8d9463324ab920a6d9c3b832a1cf6c1b8ae89f15f2e687478059
+oid sha256:3d785b6bd4cdc77034473b75cc9d91b75293aa8eab6e60526c6238aec89dea19
 size 7922

--- a/Content/BoomerShooter/Blueprints/Weapons/BP_BulletHole.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/BP_BulletHole.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3deb4e6aaff4420729ca76c8ec07cb7bc5da9d1d7eb853f50b41111b859d5f62
+size 26015

--- a/Content/BoomerShooter/Blueprints/Weapons/BP_BulletHole.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/BP_BulletHole.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3deb4e6aaff4420729ca76c8ec07cb7bc5da9d1d7eb853f50b41111b859d5f62
-size 26015
+oid sha256:1377fa7935238a2472c4be8c51f71e7802b286cdc9227263608fb17c009be31f
+size 15691

--- a/Content/BoomerShooter/Blueprints/Weapons/BP_Pistol.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/BP_Pistol.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f3bff8577c269c443b829e7f657c6c9f73bab401e49a7341ca87ae195e286e12
-size 93623
+oid sha256:c7053fd0dafa858eb7906cf8daa0b274a18ec40094c2d959e98d0af61a4df5e0
+size 91870

--- a/Content/BoomerShooter/Blueprints/Weapons/BP_Pistol.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/BP_Pistol.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3bff8577c269c443b829e7f657c6c9f73bab401e49a7341ca87ae195e286e12
+size 93623

--- a/Content/BoomerShooter/Blueprints/Weapons/BP_PlayerWeaponBase.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/BP_PlayerWeaponBase.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:12bb0c8a0eaf9c326d6e00884a5510d7f21988b93a8afc1e6c7d12bc56c9b8ef
-size 110690
+oid sha256:07daf7b693938972c70bfda81d66a29fe2823dd4edd26f19140c417f6f2e580c
+size 109280

--- a/Content/BoomerShooter/Blueprints/Weapons/DT_Weapons.uasset
+++ b/Content/BoomerShooter/Blueprints/Weapons/DT_Weapons.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65fa0b5d83a0e95a224425702dd30f3b7e8f61270e07c888aa33f9560ee2ee85
-size 3188
+oid sha256:7b9cc2e116ace8fe6b14df3d97be6cc63df47226aa39a47b703e3a9b57a4700f
+size 3592

--- a/Content/BoomerShooter/Blueprints/Widgets/WBP_HUD.uasset
+++ b/Content/BoomerShooter/Blueprints/Widgets/WBP_HUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15f5da2a8c9c86f02c134ac897833e5c53561f6c81db07f06b770dc738d429c7
-size 59874
+oid sha256:eabc474856c9c3ceafdc83f8331d04b42c0355726cba1ebdcceeb581686a330a
+size 59194

--- a/Content/BoomerShooter/Blueprints/Widgets/WBP_HUD.uasset
+++ b/Content/BoomerShooter/Blueprints/Widgets/WBP_HUD.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2109b36453e710ef2200b30410e1ffd18859cb598128eff94eed3ed4d4bdbff6
-size 52666
+oid sha256:15f5da2a8c9c86f02c134ac897833e5c53561f6c81db07f06b770dc738d429c7
+size 59874

--- a/Content/BoomerShooter/Flipbooks/FB_DeagleFire.uasset
+++ b/Content/BoomerShooter/Flipbooks/FB_DeagleFire.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:429f8b9980a8973a647f9b20e3fdfa7a92b883c45aa88037bc583e9ac97b6d9d
+size 12886

--- a/Content/BoomerShooter/Flipbooks/FB_DeagleIdle.uasset
+++ b/Content/BoomerShooter/Flipbooks/FB_DeagleIdle.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5628d7790e8c59650d7d8fe4c924ac94b48b79a683bee47b6a25dff1b0356bf0
+size 12662

--- a/Content/BoomerShooter/Flipbooks/Pickups/FB_PistolAmmo.uasset
+++ b/Content/BoomerShooter/Flipbooks/Pickups/FB_PistolAmmo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e6ace46b580841bd7cc13adae85df187ac64d655cdf52ef1d76767b81067bd7f
-size 10032
+oid sha256:83844f2108dc181a6dbd7156b413d558a1e9ecb2bc1601bdd4d51220d5ac250b
+size 10040

--- a/Content/BoomerShooter/Flipbooks/Pickups/FB_PistolAmmo.uasset
+++ b/Content/BoomerShooter/Flipbooks/Pickups/FB_PistolAmmo.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ace46b580841bd7cc13adae85df187ac64d655cdf52ef1d76767b81067bd7f
+size 10032

--- a/Content/BoomerShooter/Flipbooks/Pickups/FB_ShotgunPickup.uasset
+++ b/Content/BoomerShooter/Flipbooks/Pickups/FB_ShotgunPickup.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2076883aadb293545b92db218df77d3c508693ed1419cd2a8e82a4f9aa39ce7
+size 11198

--- a/Content/BoomerShooter/Input/IA_Dash.uasset
+++ b/Content/BoomerShooter/Input/IA_Dash.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f96463e0474ee59f866f816aa747ea21657a51bafc11cb52088dbee84ce580d
+size 1376

--- a/Content/BoomerShooter/Input/IA_FireWeapon.uasset
+++ b/Content/BoomerShooter/Input/IA_FireWeapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4de453f0ced893366544ccd1d6b7171af6d5f2cfe4e8f61db5fce8f58ea669d
+size 1710

--- a/Content/BoomerShooter/Input/IA_Jump.uasset
+++ b/Content/BoomerShooter/Input/IA_Jump.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a73602766ccf04ddd1bfc74a83eb91f98fba20cf6a9d03fac7a8b377f18b282
+size 1376

--- a/Content/BoomerShooter/Input/IA_Look.uasset
+++ b/Content/BoomerShooter/Input/IA_Look.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8abb008e7a28741086fa995416187ac93cc700321bfbe4628ed6438e47c5a332
+size 1572

--- a/Content/BoomerShooter/Input/IA_Move.uasset
+++ b/Content/BoomerShooter/Input/IA_Move.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6a08cbc5b6bb8f461ce5091f3ee81936e013d492a3a857641a11e13617191a8
+size 1572

--- a/Content/BoomerShooter/Input/IA_SwitchPistol.uasset
+++ b/Content/BoomerShooter/Input/IA_SwitchPistol.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6e6b444d2b712ef4cc12f79ae0175b4c088d9bfa2354a57af1618d7e2d3a256
+size 1416

--- a/Content/BoomerShooter/Input/IA_SwitchShotgun.uasset
+++ b/Content/BoomerShooter/Input/IA_SwitchShotgun.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a327f4db16b2e36d1df14f72da86abfd43244659329f838f6dbe13c7d2c99d5
+size 1421

--- a/Content/BoomerShooter/Input/IMC_Player.uasset
+++ b/Content/BoomerShooter/Input/IMC_Player.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0613b1338afcf86651e2905af8b6936e988e5e252171a81d294c58443aa03a59
+size 10616

--- a/Content/BoomerShooter/Input/InputAction/IA_Dash.uasset
+++ b/Content/BoomerShooter/Input/InputAction/IA_Dash.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ad5ce037593d1317dfa5f7a2861c2bebd39f0dbcce8da95716b9264e2e4b34b3
-size 1400

--- a/Content/BoomerShooter/Input/InputAction/IA_FireWeapon.uasset
+++ b/Content/BoomerShooter/Input/InputAction/IA_FireWeapon.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cd3bf599cb7f8c2e2a89d980728badd424f34312a2403c67e7fe1cda7fb8f5b
-size 1734

--- a/Content/BoomerShooter/Input/InputAction/IA_Jump.uasset
+++ b/Content/BoomerShooter/Input/InputAction/IA_Jump.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c5e77629a9f0ba6ff91c52e334391548b135b8c3a0fcc12a154b8ca0d2521d8
-size 1400

--- a/Content/BoomerShooter/Input/InputAction/IA_Look.uasset
+++ b/Content/BoomerShooter/Input/InputAction/IA_Look.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee6ec02f459e8e6a2d49768b276454968546b7cbc9b8c0fc5865c1dff3c57679
-size 1596

--- a/Content/BoomerShooter/Input/InputAction/IA_Move.uasset
+++ b/Content/BoomerShooter/Input/InputAction/IA_Move.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d210a1c27eacf7b61384c2ec2b0ad1e4a2b7e05f647edc9e840e302009a8e940
-size 1596

--- a/Content/BoomerShooter/Input/InputMappingContext/IMC_Player.uasset
+++ b/Content/BoomerShooter/Input/InputMappingContext/IMC_Player.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c82bf1c3368382769c33cfe055b65692b3b9cbdcec7f4595e7b6466fb1509b9c
-size 9138

--- a/Content/BoomerShooter/Materials/M_FPSSprite.uasset
+++ b/Content/BoomerShooter/Materials/M_FPSSprite.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b44cb114d747e7674d320ee408d636a7bc548169b91f4ae5ccbca90423217ed9
-size 16205
+oid sha256:5f090b5342793bb930c93d3af1a76098b0f64897217ceed7e2a43a3b0f5f8f45
+size 16204

--- a/Content/BoomerShooter/Textures/CRT_Weapon.uasset
+++ b/Content/BoomerShooter/Textures/CRT_Weapon.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:108415a515fccd63cebb14af79980c644e68d7a0a41333a67d6c08db5fa0f6af
-size 4090

--- a/Content/BoomerShooter/Textures/M_CRT_Weapon.uasset
+++ b/Content/BoomerShooter/Textures/M_CRT_Weapon.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:038893b668edf205963ec9fafce9ad552f6cf064063d08ebd70e1efe5834522d
-size 10539

--- a/Content/BoomerShooter/Textures/Weapons/CRT_Weapon.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/CRT_Weapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf86f41bd803c7df37bb4abbd772bea1645856932689bf9f7030eeb77b33a49b
+size 4318

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c500eede96da4fb6fb76ec861e073979286dbc1c5418d186a5f0105f3aea830
+size 101360

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_0.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_0.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8057e687a487587e64e9826ae30343f8e3f58a91ccd56568686fe522efd0a85f
+size 16953

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_1.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eee649841f77d6180e0ef5faadc5f493f5b9b05ad631f8dc2715d062be2a039b
+size 18859

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_2.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_2.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f543543a2c664992558a507140808f161069a44e8bc756ad8abc1ff861f7741a
+size 19558

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_3.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_3.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b99b36e28738efc9b6113d609b8d580283612a27a261a1846e3c0aae9548bbd
+size 17209

--- a/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_4.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/IzUcE7_Sprite_4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:243ef4d81d609698a7621f81c7439837cc04633d2db7cf2ca76a20562ebe7b3d
+size 16729

--- a/Content/BoomerShooter/Textures/Weapons/M_CRT_Weapon.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/M_CRT_Weapon.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96d2bf753d6fe8082e338be5c6401a5b4d30c2f2593fea4414e3694cc2e7ae1a
+size 10563

--- a/Content/BoomerShooter/Textures/Weapons/Shotgun.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/Shotgun.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f35641e0acdaa4ce83d37b3c88b552eb7bd57dbbb1da113e5ea5bad51d02ce8
+size 11705

--- a/Content/BoomerShooter/Textures/Weapons/Shotgun_Sprite.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/Shotgun_Sprite.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:705bdd75921e36b9c8effc2c1481f6f44f20b1b1448608507f0374769ec54a3c
+size 15204

--- a/Content/BoomerShooter/Textures/Weapons/ammo-pistol_32px.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/ammo-pistol_32px.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7cf79fcfef2c772753cb9dc3d145a44b3cb86f963e7b8b7d8f8aca1af9fe518
+size 10827

--- a/Content/BoomerShooter/Textures/Weapons/ammo-pistol_32px_Sprite.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/ammo-pistol_32px_Sprite.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb8cba5da5182b31cabeb713bcc6fa2fe86a3efd2ee670cce14ca2f49b50b505
+size 14124

--- a/Content/BoomerShooter/Textures/Weapons/bullet_hole.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/bullet_hole.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a63c834598d2346b7a99037929525437b2f5d806be0837307cb8627f92815352
+size 372913

--- a/Content/BoomerShooter/Textures/Weapons/bullet_hole_Sprite.uasset
+++ b/Content/BoomerShooter/Textures/Weapons/bullet_hole_Sprite.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4cdfb1554f77c70fe3326e8e835cd2d6df7854f8b06b14e5b83831a5e6dbad
+size 16800

--- a/Content/BoomerShooter/Textures/ammo-pistol_32px.uasset
+++ b/Content/BoomerShooter/Textures/ammo-pistol_32px.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17077ec3c3fb655fd207c2a775d2139185a5948a34e741755147c915b7c9b8e2
+size 10566

--- a/Content/BoomerShooter/Textures/ammo-pistol_32px.uasset
+++ b/Content/BoomerShooter/Textures/ammo-pistol_32px.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17077ec3c3fb655fd207c2a775d2139185a5948a34e741755147c915b7c9b8e2
-size 10566

--- a/Content/BoomerShooter/Textures/ammo-pistol_32px_Sprite.uasset
+++ b/Content/BoomerShooter/Textures/ammo-pistol_32px_Sprite.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee2640a74e3341e47b3a897553afcdaaacbae2f912adcfec495a77310c9a1159
-size 14092

--- a/Content/BoomerShooter/Textures/ammo-pistol_32px_Sprite.uasset
+++ b/Content/BoomerShooter/Textures/ammo-pistol_32px_Sprite.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee2640a74e3341e47b3a897553afcdaaacbae2f912adcfec495a77310c9a1159
+size 14092

--- a/Source/BoomerShooter/FPSAttributeSet.cpp
+++ b/Source/BoomerShooter/FPSAttributeSet.cpp
@@ -20,9 +20,13 @@ void UFPSAttributeSet::PreAttributeChange(const FGameplayAttribute& Attribute, f
 	{
 		NewValue = FMath::Clamp<float>(NewValue, 0, Character->MaxArmor);
 	}
-	else if (Attribute == GetBulletsAttribute())
+	else if (Attribute == GetShotgunAmmoAttribute())
 	{
-		NewValue = FMath::Clamp<float>(NewValue, 0, Character->MaxBullets);
+		NewValue = FMath::Clamp<float>(NewValue, 0, Character->MaxShotgunAmmo);
+	}
+	else if (Attribute == GetPistolAmmoAttribute())
+	{
+		NewValue = FMath::Clamp<float>(NewValue, 0, Character->MaxPistolAmmo);
 	}
 }
 
@@ -44,9 +48,14 @@ bool UFPSAttributeSet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& 
 			SetHealth(Character->MaxHealth);
 			return false;
 		}
-		else if (Data.EvaluatedData.Attribute == GetBulletsAttribute() && GetBullets() + AbsoluteMagnitude >= Character->MaxBullets)
+		else if (Data.EvaluatedData.Attribute == GetShotgunAmmoAttribute() && GetShotgunAmmo() + AbsoluteMagnitude >= Character->MaxShotgunAmmo)
 		{
-			SetBullets(Character->MaxBullets);
+			SetShotgunAmmo(Character->MaxShotgunAmmo);
+			return false;
+		}
+		else if (Data.EvaluatedData.Attribute == GetPistolAmmoAttribute() && GetPistolAmmo() + AbsoluteMagnitude >= Character->MaxPistolAmmo)
+		{
+			SetPistolAmmo(Character->MaxPistolAmmo);
 			return false;
 		}
 	}
@@ -72,8 +81,12 @@ void UFPSAttributeSet::PostGameplayEffectExecute(const FGameplayEffectModCallbac
 	{
 		SetArmor(0);
 	}
-	else if (Data.EvaluatedData.Attribute == GetBulletsAttribute() && GetBullets() < 0)
+	else if (Data.EvaluatedData.Attribute == GetShotgunAmmoAttribute() && GetShotgunAmmo() < 0)
 	{
-		SetBullets(0);
+		SetShotgunAmmo(0);
+	}
+	else if (Data.EvaluatedData.Attribute == GetPistolAmmoAttribute() && GetPistolAmmo() < 0)
+	{
+		SetPistolAmmo(0);
 	}
 }

--- a/Source/BoomerShooter/FPSAttributeSet.h
+++ b/Source/BoomerShooter/FPSAttributeSet.h
@@ -34,8 +34,12 @@ public:
 	ATTRIBUTE_ACCESSOR(UFPSAttributeSet, Armor)
 
 	UPROPERTY(BlueprintReadOnly, Category = "Attributes")
-	FGameplayAttributeData Bullets;
-	ATTRIBUTE_ACCESSOR(UFPSAttributeSet, Bullets)
+	FGameplayAttributeData ShotgunAmmo;
+	ATTRIBUTE_ACCESSOR(UFPSAttributeSet, ShotgunAmmo)
+
+	UPROPERTY(BlueprintReadOnly, Category = "Attributes")
+	FGameplayAttributeData PistolAmmo;
+	ATTRIBUTE_ACCESSOR(UFPSAttributeSet, PistolAmmo)
 
 	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
 	virtual bool PreGameplayEffectExecute(struct FGameplayEffectModCallbackData& Data) override;

--- a/Source/BoomerShooter/FPSCharacter.h
+++ b/Source/BoomerShooter/FPSCharacter.h
@@ -38,7 +38,10 @@ public:
 	int MaxArmor = 100;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Attributes")
-	int MaxBullets = 250;
+	int MaxPistolAmmo = 12;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Attributes")
+	int MaxShotgunAmmo = 80;
 
 protected:
 	// Called when the game starts or when spawned

--- a/Source/BoomerShooter/ObjectsPool.cpp
+++ b/Source/BoomerShooter/ObjectsPool.cpp
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "ObjectsPool.h"
+
+// Sets default values for this component's properties
+UObjectsPool::UObjectsPool()
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = true;
+
+	// ...
+}
+
+
+// Called when the game starts
+void UObjectsPool::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// ...
+	
+}
+
+
+// Called every frame
+void UObjectsPool::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	// ...
+}
+

--- a/Source/BoomerShooter/ObjectsPool.h
+++ b/Source/BoomerShooter/ObjectsPool.h
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "ObjectsPool.generated.h"
+
+
+UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
+class BOOMERSHOOTER_API UObjectsPool : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:	
+	// Sets default values for this component's properties
+	UObjectsPool();
+
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+
+public:	
+	// Called every frame
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+		
+};

--- a/Source/BoomerShooter/PooledObject.cpp
+++ b/Source/BoomerShooter/PooledObject.cpp
@@ -1,0 +1,34 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PooledObject.h"
+
+// Sets default values
+APooledObject::APooledObject()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+void APooledObject::SetActive(bool IsActive)
+{
+}
+
+void APooledObject::SetLifeSpan(float LifeSpan)
+{
+}
+
+void APooledObject::SetPoolIndex(int Index)
+{
+}
+
+bool APooledObject::IsActive() const
+{
+	return false;
+}
+
+int APooledObject::GetPoolIndex() const
+{
+	return 0;
+}

--- a/Source/BoomerShooter/PooledObject.h
+++ b/Source/BoomerShooter/PooledObject.h
@@ -1,0 +1,43 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "PooledObject.generated.h"
+#include "PooledObject.h"
+#include "Delegates/Delegate.h"
+#include "Delegates/DelegateCombinations.h"
+
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnPooledObjectDespawn, APooledObject*, PoolActor);
+
+UCLASS()
+class BOOMERSHOOTER_API APooledObject : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	APooledObject();
+
+	FOnPooledObjectDespawn OnPooledObjectDespawn;
+
+	UFUNCTION(BlueprintCallable, Category = "Pooled Object")
+		void Deactivate();
+
+	void SetActive(bool IsActive);
+	void SetLifeSpan(float LifeSpan);
+	void SetPoolIndex(int Index);
+
+	bool IsActive() const;
+	int GetPoolIndex() const;
+
+protected:
+	
+	bool Active;
+	float LifeSpan = 0.0f;
+	int PoolIndex;
+
+	FTimerHandle LifeSpanTimer;
+};


### PR DESCRIPTION
Changes relate to #1 and #5 
- Made some changes to how the weapon system is implemented to better allow addition of extra guns.
- Readded pistol to the game that uses seperate ammo. Currently thought of as a extremely high damage pistol with very limited ammo available in levels, but of course can change or be removed based on needs.
- HUD updates ammo displayed based on weapon equipped in hand.
- Ammo can be accessed in ability system component of the BP_Player.
- Removed logic for transforming weapon pickup textures from weapon textures to ammo textures based on if you already own the weapon. Will probably end up creating seperate ammo pickups later. WIP.
- Added bullet holes that get created on a non actor surface when shooting. Created a system for despawning bullet holes in the world when a certain number of them are created. Works with a First In First Out system.
- Player can now swap between shotgun and pistol (provided they have unlocked them) with 1 and 2 on the keyboard.